### PR TITLE
Add b3doc package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -27,5 +27,9 @@
         "package": "rgbif",
         "url": "https://github.com/ropensci/rgbif",
         "branch": "master"
+    },
+    {
+        "package": "b3doc",
+        "url": "https://github.com/b-cubed-eu/b3doc"
     }
 ]


### PR DESCRIPTION
This package is not required for users, but it is part of the B-Cubed suite of R packages, so I think it's worth adding it.